### PR TITLE
Restructure the pipeline to take just one .fastq file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker image build -t rnaseq-pipe .
 run-pipeline.sh <REF_DIR> <FASTQ_DIR> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
 
         REF_DIR         Directory containing reference files
-        FASTQ_DIR       Directory containing .fastq files to run through the pipeline
+        FASTQ_FILE      Path to .fastq files to run through the pipeline
         STAR_INDEX_DIR  Directory containing STAR indices
         GENOME_VERSION  Human Genome version prefix used in REF_DIR files
         NUM_CORES       Number of CPU cores to use in pipeline.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker image build -t rnaseq-pipe .
 ### Without Docker:
 
 ```
-run-pipeline.sh <REF_DIR> <FASTQ_DIR> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
+run-pipeline.sh <REF_DIR> <FASTQ_FILE> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
 
         REF_DIR         Directory containing reference files
         FASTQ_FILE      Path to .fastq files to run through the pipeline

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -7,7 +7,7 @@ then
     echo "Usage: run-pipeline.sh <REF_DIR> <FASTQ_DIR> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
 
         REF_DIR         Directory containing reference files
-        FASTQ_DIR       Directory containing .fastq files to run through the pipeline
+        FASTQ_FILE      Path to .fastq file to run through the pipeline
         STAR_INDEX_DIR  Directory containing STAR indices
         GENOME_VERSION  Human Genome version prefix used in REF_DIR files
         NUM_CORES       Number of CPU cores to use in pipeline.

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -4,7 +4,7 @@ set -e -u
 
 if [ "$#" -ne "6" ]
 then
-    echo "Usage: run-pipeline.sh <REF_DIR> <FASTQ_DIR> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
+    echo "Usage: run-pipeline.sh <REF_DIR> <FASTQ_FILE> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
 
         REF_DIR         Directory containing reference files
         FASTQ_FILE      Path to .fastq file to run through the pipeline

--- a/src/rnaseq-pipeline.nf
+++ b/src/rnaseq-pipeline.nf
@@ -9,7 +9,7 @@
  *
  */
 
-// path to fastq file
+// fastq file directory
 params.fastq             = ""
 
 // path to STAR indexes
@@ -39,13 +39,13 @@ params.cores    = 32
 
 process STAR {
         input:
-        file fastq_file from Channel.fromPath( params.fastq  + "/*.fastq")
+        file fastq_file from Channel.fromPath( params.fastq)
 
         publishDir "${params.output_dir}/${fastq_file.baseName}/STAR_OUT", mode: 'link'
 
         output:
         set val(fastq_file), file("${fastq_file.baseName}_Aligned.sortedByCoord.out.bam") into STAR_out_1
-	set val(fastq_file), file("${fastq_file.baseName}_Aligned.sortedByCoord.out.bam") into STAR_out_2
+        set val(fastq_file), file("${fastq_file.baseName}_Aligned.sortedByCoord.out.bam") into STAR_out_2
         set val(fastq_file), file("${fastq_file.baseName}_Aligned.sortedByCoord.out.bam") into STAR_out_3
         file '*' into STAR_DIR
 


### PR DESCRIPTION
Taking multiple files is redundant since a simple bash script can
be written to loop through all .fastq files so this functionality
is removed for simplicity.