### PR TITLE
Add support for paired-ends & replicates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,18 @@ docker image build -t rnaseq-pipe .
 ### Without Docker:
 
 ```
-Usage: ./run-pipeline.sh -R <REF_DIR> -F <FASTQ_FILE> -I <STAR_INDEX_DIR> -G <GENOME_VERSION> -P <NUM_CORES> -O <OUTPUT_DIR>
+Usage: ./run-pipeline.sh -R <REF_DIR> -F <FASTQ_FILE> -I <STAR_INDEX_DIR> -G <GENOME_VERSION> -P <NUM_CORES> -O <OUTPUT_DIR> -S <SAMPLE_NAME>
 
                 -R <REF_DIR>         Directory containing reference files
-                -F <FASTQ_FILE>      Path to .fastq file to run through the pipeline
+                -F <FASTQ_FILE>      Path to .fastq file(s) to run through the pipeline.
+                                     Separate paired-ends with spaces & replicates by comma.
+                                     Eg: -F \"pair1_sample1,pair1_sample2...pair1_sampleN pair2_sample1,pair2_sample2...pair2_sampleN\"
+                                     NOTE: MUST BE ENCLOSED IN QUOTES FOR PAIRED-END/REPLICATES.
                 -I <STAR_INDEX_DIR>  Directory containing STAR indices
                 -G <GENOME_VERSION>  Human Genome version prefix used in REF_DIR files
                 -P <NUM_CORES>       Number of CPU cores to use in pipeline.
                 -O <OUTPUT_DIR>      Directory to save output from pipeline.
+                -S <SAMPLE_NAME>     Prefix name for output files.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ docker image build -t rnaseq-pipe .
 ### Without Docker:
 
 ```
-run-pipeline.sh <REF_DIR> <FASTQ_FILE> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
+Usage: ./run-pipeline.sh -R <REF_DIR> -F <FASTQ_FILE> -I <STAR_INDEX_DIR> -G <GENOME_VERSION> -P <NUM_CORES> -O <OUTPUT_DIR>
 
-        REF_DIR         Directory containing reference files
-        FASTQ_FILE      Path to .fastq files to run through the pipeline
-        STAR_INDEX_DIR  Directory containing STAR indices
-        GENOME_VERSION  Human Genome version prefix used in REF_DIR files
-        NUM_CORES       Number of CPU cores to use in pipeline.
-        OUTPUT_DIR      Directory to save output from pipeline.
+                -R <REF_DIR>         Directory containing reference files
+                -F <FASTQ_FILE>      Path to .fastq file to run through the pipeline
+                -I <STAR_INDEX_DIR>  Directory containing STAR indices
+                -G <GENOME_VERSION>  Human Genome version prefix used in REF_DIR files
+                -P <NUM_CORES>       Number of CPU cores to use in pipeline.
+                -O <OUTPUT_DIR>      Directory to save output from pipeline.
 
 ```
 

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -4,10 +4,14 @@ set -e -u
 
 usage()
 {
-    echo "Usage: ./run-pipeline.sh -R <REF_DIR> -F <FASTQ_FILE> -I <STAR_INDEX_DIR> -G <GENOME_VERSION> -P <NUM_CORES> -O <OUTPUT_DIR>
+    echo "Usage: ./run-pipeline.sh -R <REF_DIR> -F <FASTQ_FILE> -I <STAR_INDEX_DIR> -G <GENOME_VERSION> -P <NUM_CORES> -O <OUTPUT_DIR> -S <SAMPLE_NAME>
 
                 -R <REF_DIR>         Directory containing reference files
-                -F <FASTQ_FILE>      Path to .fastq file to run through the pipeline
+                -F <FASTQ_FILE>      Path to .fastq file(s) to run through the pipeline.
+                                     Supports paired-ends & replicates.
+                                     Separate paired-ends with spaces & replicates by comma.
+                                     Eg: -F \"pair1_sample1,pair1_sample2...pair1_sampleN pair2_sample1,pair2_sample2...pair2_sampleN\"
+                                     NOTE: MUST BE ENCLOSED IN QUOTES FOR PAIRED-END/REPLICATES.
                 -I <STAR_INDEX_DIR>  Directory containing STAR indices
                 -G <GENOME_VERSION>  Human Genome version prefix used in REF_DIR files
                 -P <NUM_CORES>       Number of CPU cores to use in pipeline.

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -12,10 +12,11 @@ usage()
                 -G <GENOME_VERSION>  Human Genome version prefix used in REF_DIR files
                 -P <NUM_CORES>       Number of CPU cores to use in pipeline.
                 -O <OUTPUT_DIR>      Directory to save output from pipeline.
+                -S <SAMPLE_NAME>     Prefix name for output files.
             "
 }
 
-OPTIONS=":R:F:I:G:P:O:h"
+OPTIONS=":R:F:I:G:P:O:S:h"
 
 REF_DIR=''
 FASTQ_FILE=''
@@ -23,6 +24,7 @@ STAR_INDEX_DIR=''
 GENOME_VERSION=''
 NUM_CORES=''
 OUTPUT_DIR=''
+SAMPLE_NAME=''
 
 while getopts $OPTIONS opt; do
     case $opt in
@@ -38,6 +40,8 @@ while getopts $OPTIONS opt; do
         NUM_CORES=$OPTARG ;;
     O)
         OUTPUT_DIR=$OPTARG ;;
+    S)
+        SAMPLE_NAME=$OPTARG ;;
     h)
         usage
         exit 0 ;;
@@ -61,7 +65,8 @@ then
 fi
 
 if [[ -z $REF_DIR ]] || [[ -z $FASTQ_FILE ]] || [[ -z $STAR_INDEX_DIR ]] || \
-[[ -z $GENOME_VERSION ]] || [[ -z $NUM_CORES ]] || [[ -z $OUTPUT_DIR ]]
+[[ -z $GENOME_VERSION ]] || [[ -z $NUM_CORES ]] || [[ -z $OUTPUT_DIR ]] ||
+[[ -z $SAMPLE_NAME ]]
 then
     usage
     exit 1
@@ -73,10 +78,10 @@ echo "STAR_INDEX_DIR = $STAR_INDEX_DIR"
 echo "GENOME_VERSION = $GENOME_VERSION"
 echo "NUM_CORES = $NUM_CORES"
 echo "OUTPUT_DIR = $OUTPUT_DIR"
+echo "SAMPLE_NAME = $SAMPLE_NAME"
 
 ref_gene="$REF_DIR/$GENOME_VERSION.refGene_gene_longest.gtf"
 ref_fasta="$REF_DIR/$GENOME_VERSION.fa"
 
-cmd="nextflow run ./src/rnaseq-pipeline.nf --fastq $FASTQ_FILE --STAR_index $STAR_INDEX_DIR --ref_dir $REF_DIR --ref_gene $ref_gene --ref_fasta $ref_fasta --output_dir $OUTPUT_DIR --cores $NUM_CORES"
-echo "Executing $cmd"
+cmd="nextflow run ./src/rnaseq-pipeline.nf --fastq $FASTQ_FILE --STAR_index $STAR_INDEX_DIR --ref_dir $REF_DIR --ref_gene $ref_gene --ref_fasta $ref_fasta --output_dir $OUTPUT_DIR --cores $NUM_CORES --sample_name $SAMPLE_NAME"
 $cmd

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -2,22 +2,81 @@
 
 set -e -u
 
-if [ "$#" -ne "6" ]
+usage()
+{
+    echo "Usage: ./run-pipeline.sh -R <REF_DIR> -F <FASTQ_FILE> -I <STAR_INDEX_DIR> -G <GENOME_VERSION> -P <NUM_CORES> -O <OUTPUT_DIR>
+
+                -R <REF_DIR>         Directory containing reference files
+                -F <FASTQ_FILE>      Path to .fastq file to run through the pipeline
+                -I <STAR_INDEX_DIR>  Directory containing STAR indices
+                -G <GENOME_VERSION>  Human Genome version prefix used in REF_DIR files
+                -P <NUM_CORES>       Number of CPU cores to use in pipeline.
+                -O <OUTPUT_DIR>      Directory to save output from pipeline.
+            "
+}
+
+OPTIONS=":R:F:I:G:P:O:h"
+
+REF_DIR=''
+FASTQ_FILE=''
+STAR_INDEX_DIR=''
+GENOME_VERSION=''
+NUM_CORES=''
+OUTPUT_DIR=''
+
+while getopts $OPTIONS opt; do
+    case $opt in
+    R)
+        REF_DIR=$OPTARG ;;
+    F)
+        FASTQ_FILE=$OPTARG ;;
+    I)
+        STAR_INDEX_DIR=$OPTARG ;;
+    G)
+        GENOME_VERSION=$OPTARG ;;
+    P)
+        NUM_CORES=$OPTARG ;;
+    O)
+        OUTPUT_DIR=$OPTARG ;;
+    h)
+        usage
+        exit 0 ;;
+    \?)
+        echo "Unrecognized option: -$OPTARG"
+        usage
+        exit 1 ;;
+    :)
+        echo "Error: -$OPTARG requires an argument."
+        usage
+        exit 1 ;;
+    esac
+done
+
+shift $(expr $OPTIND - 1 )
+if [[ $# -gt 0 ]]
 then
-    echo "Usage: run-pipeline.sh <REF_DIR> <FASTQ_FILE> <STAR_INDEX_DIR> <GENOME_VERSION> <NUM_CORES> <OUTPUT_DIR>
-        REF_DIR         Directory containing reference files
-        FASTQ_FILE      Path to .fastq file to run through the pipeline
-        STAR_INDEX_DIR  Directory containing STAR indices
-        GENOME_VERSION  Human Genome version prefix used in REF_DIR files
-        NUM_CORES       Number of CPU cores to use in pipeline.
-        OUTPUT_DIR      Directory to save output from pipeline.
-    "
-    exit
+    echo "Unrecognized options: $*"
+    usage
+    exit 1
 fi
 
-ref_gene="$1/$4.refGene_gene_longest.gtf"
-ref_fasta="$1/$4.fa"
+if [[ -z $REF_DIR ]] || [[ -z $FASTQ_FILE ]] || [[ -z $STAR_INDEX_DIR ]] || \
+[[ -z $GENOME_VERSION ]] || [[ -z $NUM_CORES ]] || [[ -z $OUTPUT_DIR ]]
+then
+    usage
+    exit 1
+fi
 
-cmd="nextflow run ./src/rnaseq-pipeline.nf --fastq $2 --STAR_index $3 --ref_dir $1 --ref_gene $ref_gene --ref_fasta $ref_fasta --output_dir $6 --cores $5"
-echo $cmd
+echo "REF_DIR = $REF_DIR"
+echo "FASTQ_FILE = $FASTQ_FILE"
+echo "STAR_INDEX_DIR = $STAR_INDEX_DIR"
+echo "GENOME_VERSION = $GENOME_VERSION"
+echo "NUM_CORES = $NUM_CORES"
+echo "OUTPUT_DIR = $OUTPUT_DIR"
+
+ref_gene="$REF_DIR/$GENOME_VERSION.refGene_gene_longest.gtf"
+ref_fasta="$REF_DIR/$GENOME_VERSION.fa"
+
+cmd="nextflow run ./src/rnaseq-pipeline.nf --fastq $FASTQ_FILE --STAR_index $STAR_INDEX_DIR --ref_dir $REF_DIR --ref_gene $ref_gene --ref_fasta $ref_fasta --output_dir $OUTPUT_DIR --cores $NUM_CORES"
+echo "Executing $cmd"
 $cmd

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -83,5 +83,5 @@ echo "SAMPLE_NAME = $SAMPLE_NAME"
 ref_gene="$REF_DIR/$GENOME_VERSION.refGene_gene_longest.gtf"
 ref_fasta="$REF_DIR/$GENOME_VERSION.fa"
 
-cmd="nextflow run ./src/rnaseq-pipeline.nf --fastq $FASTQ_FILE --STAR_index $STAR_INDEX_DIR --ref_dir $REF_DIR --ref_gene $ref_gene --ref_fasta $ref_fasta --output_dir $OUTPUT_DIR --cores $NUM_CORES --sample_name $SAMPLE_NAME"
+cmd="nextflow run ./src/rnaseq-pipeline.nf --fastq '$FASTQ_FILE' --STAR_index $STAR_INDEX_DIR --ref_dir $REF_DIR --ref_gene $ref_gene --ref_fasta $ref_fasta --output_dir $OUTPUT_DIR --cores $NUM_CORES --sample_name $SAMPLE_NAME"
 $cmd

--- a/src/rnaseq-pipeline.nf
+++ b/src/rnaseq-pipeline.nf
@@ -97,17 +97,17 @@ process cufflinks {
 
 process intron_analysis {
         input:
-        set val(fastq_file), file(bam_file) from STAR_out_3
+        file(bam_file) from STAR_out_3
         file(fpkm_file) from CUFFLINKS_out_1 
         file(junctions_file) from REGTOOLS_out_1
 
-        publishDir "${params.output_dir}/${fastq_file.baseName}/"
+        publishDir "${params.output_dir}/${params.sample_name}/", mode: 'link'
 
         output:
-        file("${fastq_file.baseName}_intron_analysis.txt") into ANALYSIS_DIR_1
-        file("${fastq_file.baseName}_total_cvg.txt") into ANALYSIS_DIR_2
+        file("${params.sample_name}_intron_analysis.txt") into ANALYSIS_DIR_1
+        file("${params.sample_name}_total_cvg.txt") into ANALYSIS_DIR_2
 
         """
-        $splicing_analysis $params.ref_dir $bam_file $junctions_file $fpkm_file $params.gene_version $fastq_file.baseName
+        $splicing_analysis $params.ref_dir $bam_file $junctions_file $fpkm_file $params.gene_version $params.sample_name
         """
 }

--- a/src/rnaseq-pipeline.nf
+++ b/src/rnaseq-pipeline.nf
@@ -90,7 +90,7 @@ process cufflinks {
         """
         cufflinks -p $params.cores -G $params.ref_gene -b $params.ref_fasta -L experiment_descriptor -u $bam_file
         """
-        
+
 }
 
 process intron_analysis {


### PR DESCRIPTION
This PR rewrites the script and wrapper to enable support for paired-ends & replicates. 

This was primarily accomplished by treating the `--FASTQ_FILE` as a string in nextflow instead of a file. This means that we can now pass in paired-ends & replicates as follows: 

`-F "pair1_sample1,pair1_sample2 pair2_sample1,pair2_sample2"`

This is how STAR takes in paired-ends & replicates and since this will be directly passed to STAR, we handle this case cleanly. 

As a side effect, an additional argument called `SAMPLE_NAME` is added to the script & wrapper. This is important because previously the output files would be prefixed with the name of the single .fastq file passed as input. This can no longer be done on inputs passed as paired-ends or replicates (we want to avoid weird whitespace naming), hence necessitating `SAMPLE_NAME`.