### PR TITLE
Add component to convert .bam to .bw (bigwig)

### DIFF
--- a/bin/bam2bigwig.sh
+++ b/bin/bam2bigwig.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if [ "$#" -ne "3" ]
+then
+    echo "Not enough parameters..."
+    echo "Usage: bam2bigwig.sh <accepted_hits.bam> <chrom.sizes.txt> <path_to_output_bigwig>"
+    echo "Example: bam2bigwig.sh sample1.bam hg38.chrom.sizes ~/sample1/bigwig/sample1.bw"
+    exit
+fi
+
+accepted_hits=$1
+genome_file=$2
+
+output_file_name=$(basename -- "$3")
+output_file_name="${output_file_name%.*}"
+output_path_without_ext=$(dirname -- "$3")/${output_file_name}
+
+echo "Running genomeCoverageBed..."
+genomeCoverageBed -split -bg -ibam $accepted_hits -g $genome_file > $output_file_name.interim.bedgraph
+
+echo "Running sorting on bedgraph file..."
+LC_COLLATE=C sort -k1,1 -k2,2n $output_file_name.interim.bedgraph > $output_path_without_ext.bedgraph
+
+echo "Running bedGraphToBigWig"
+bedGraphToBigWig $output_path_without_ext.bedgraph $genome_file $output_path_without_ext.bw
+
+echo "Cleaning up"
+rm $output_file_name.interim.bedgraph
+rm $output_path_without_ext.bedgraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ samtools==1.9
 bedtools==2.27
 cufflinks==2.2.1
 stringtie==1.3.4
+ucsc-bedgraphtobigwig==357

--- a/rnaseq-pipeline.nf
+++ b/rnaseq-pipeline.nf
@@ -148,7 +148,7 @@ process regtools {
     set val(sample), file(bam_file) from bam_for_regtools
 
     publishDir "${params.output_dir}/$sample/regtools", mode: 'copy'
-    publishDir "${params.output_dir}/$sample/UCSC", mode: 'copy'
+    publishDir "${params.output_dir}/$sample/UCSC_browser", mode: 'copy'
 
     output:
     file "${sample}.bed" into bed_for_intron_analysis
@@ -205,7 +205,7 @@ process bam2bigwig {
     set val(sample), file(bam_file) from bam_for_bam2bigwig
     file ref_chrom_sizes from Channel.fromPath(params.ref_dir + "/" + params.genome + ".chrom.sizes").collect()
 
-    publishDir "${params.output_dir}/$sample/UCSC", mode: 'copy'
+    publishDir "${params.output_dir}/$sample/UCSC_browser", mode: 'copy'
 
     output:
     file("${sample}.bw") into BAM2BIGIWG_DIR

--- a/rnaseq-pipeline.nf
+++ b/rnaseq-pipeline.nf
@@ -129,7 +129,7 @@ process STAR {
         STAR --genomeDir $star_index --runThreadN $params.cores --readFilesIn \$READS1 --outFileNamePrefix ${sample}_ \
         --outSAMtype BAM SortedByCoordinate --outSAMstrandField intronMotif
         """
-        
+
         else
         """
         STR1="$reads1"


### PR DESCRIPTION
A component has been added to the pipeline that convert all `.bam` files to `.bw` and stores them in a directory named `UCSC_browser`. Additionally, all `.bed` files are also moved to this directory.

The `UCSC_browser` folder contains all files necessary to visualize the sample on the [UCSC Genome Browser](https://genome.ucsc.edu/).